### PR TITLE
Bugfix/old asp core version

### DIFF
--- a/src/to.backlogrepo/to.backlogrepo.test/BacklogRepoTests.cs
+++ b/src/to.backlogrepo/to.backlogrepo.test/BacklogRepoTests.cs
@@ -40,7 +40,7 @@ namespace to.backlogrepo.test
             var id = repo.GenerateBacklogId();
 
             id.Should().Be("BCD456");
-            Directory.Exists("TestDB\\" + id).Should().BeTrue();
+            Directory.Exists(Path.Combine("TestDB",id)).Should().BeTrue();
         }
 
         [Test]

--- a/src/to.frontend/to.frontend/to.frontend.csproj
+++ b/src/to.frontend/to.frontend/to.frontend.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="6.2.2" />
     <PackageReference Include="jQuery" Version="3.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Modernizr" Version="2.8.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Update Microsoft.AspNetCore.all to 2.0.9 (security issue in older version)
fix GenerateBacklogID test which always used \ in file system paths (only working on Windows)