### PR TITLE
vscode settings for build, running tests and debug (osx and windows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -287,18 +287,9 @@ __pycache__/
 *.odx.cs
 *.xsd.cs
 
-# CDS Generated Code and Artifacts
-/Swyx.ConfigDataStoreClient.Native/IpPbxCDSWrap/include/Generated
-/Swyx.ConfigDataStoreClient.Native/IpPbxCDSWrap/Generated
-/IpPbxRCW/IpPbxSrvIDL/include
-/Swyx.ConfigDataStoreClient.Native/ClientWrapperGenerator/temp
-/ConfigDataStoreServiceMsg/MSG00409.bin
-/ConfigDataStoreServiceMsg/ConfigDataStoreMsg.rc
-/ConfigDataStoreServiceMsg/ConfigDataStoreMsg.i
-/ConfigDataStoreServiceMsg/ConfigDataStoreMsg.h
-/ConfigDataStoreServiceMsg/ConfigDataStoreMsg.cs
-/IpPbxPresMgr/IpPbxPresMgrSubs.dll
-/IpPbxRCW/IpPbxSrvRCW/DataSetActiveCalls.h
-/SWConfigDataSharedLib/Globalization/ConfigDataStoreMsg.cs
-/SWConfigDataUpdateLib/IpPbx.Sdc.Reporting.Database.dacpac
-/SWConfigDataUpdateLib/IpPbx.Database.dacpac
+# visual studio code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/to.frontend/to.frontend/bin/Debug/netcoreapp2.0/to.frontend.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src/to.frontend/to.frontend/",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart",
+            "launchBrowser": {
+                "enabled": true,
+                "args": "${auto-detect-url}",
+                "windows": {
+                    "command": "cmd.exe",
+                    "args": "/C start ${auto-detect-url}"
+                },
+                "osx": {
+                    "command": "open"
+                },
+                "linux": {
+                    "command": "xdg-open"
+                }
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/src/to.frontend/to.frontend/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,49 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet build to.build.sln",
+            "type": "shell",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "test",
+            "osx": {
+                "command": "find . -path \"**/*.test.csproj\" | xargs -n 1 dotnet test"
+            },
+            "windows": {
+                "command": "get-childitem -Recurse -Include \"*test*.csproj\" | foreach-object { dotnet test $_.fullname }",
+                "options": {
+                    "shell": {
+                        "executable": "powershell.exe",
+                        "args": [
+                            "-NoProfile",
+                            "-ExecutionPolicy",
+                            "Bypass",
+                            "-Command"
+                        ]
+                    },
+                },
+            },
+            "type": "shell",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
Added Visual Studio Code tasks.json and launch.json to build, run unit tests and debug from within VSCode. Also removed Swyx-specific gitignore settings (copy/paste error)