### PR TITLE
Make data path configurable

### DIFF
--- a/src/to.frontend/to.frontend/Controllers/LoginController.cs
+++ b/src/to.frontend/to.frontend/Controllers/LoginController.cs
@@ -14,11 +14,18 @@ using to.frontend.Models.Login;
 namespace to.frontend.Controllers
 {
     using contracts.data.result;
+    using Microsoft.Extensions.Configuration;
 
     public class LoginController : Controller
     {
+        private IConfiguration configuration;
+
         private const string errorMessageString = "errorMessage";
 
+        public LoginController(IConfiguration configuration)
+        {
+            this.configuration = configuration;
+        }
         [Route("Login")]
         [HttpGet]
         public ViewResult Login(string returnUrl)
@@ -44,7 +51,7 @@ namespace to.frontend.Controllers
                     Username = model.UserName
                 };
 
-                var handlerFactory = new RequestHandlerFactory();
+                var handlerFactory = new RequestHandlerFactory(configuration);
                 var requestHandler = handlerFactory.GetHandler();
 
                 var (status, userResult) = requestHandler.HandleLoginQuery(loginRequest);

--- a/src/to.frontend/to.frontend/Factories/IRequestHandlerFactory.cs
+++ b/src/to.frontend/to.frontend/Factories/IRequestHandlerFactory.cs
@@ -5,6 +5,7 @@ using to.security;
 using to.totalorder;
 using to.userrepo;
 using to.permissionrepo;
+using Microsoft.Extensions.Configuration;
 
 namespace to.frontend.Factories
 {
@@ -15,12 +16,20 @@ namespace to.frontend.Factories
 
     public class RequestHandlerFactory : IRequestHandlerFactory
     {
-        public IRequestHandler GetHandler()
-            => new RequestHandler(
-                new BacklogRepo(@"/TotalOrder"),
+        private IConfiguration _configuration;
+        
+        public RequestHandlerFactory(IConfiguration configuration)
+        {
+            this._configuration = configuration;
+        }
+        public IRequestHandler GetHandler() {
+            string rootPath = this._configuration.GetValue<string>("App:DataRootPath");
+            return new RequestHandler(
+                new BacklogRepo(rootPath),
                 new TotalOrder(),
-                new UserRepo(@"/TotalOrder", "users.json"),
+                new UserRepo(rootPath, "users.json"),
                 new Security(),
-                new PermissionRepo(@"/TotalOrder", "permissions.json"));
+                new PermissionRepo(rootPath, "permissions.json"));
+        }
     }
 }

--- a/src/to.frontend/to.frontend/appsettings.Development.json
+++ b/src/to.frontend/to.frontend/appsettings.Development.json
@@ -6,5 +6,8 @@
       "System": "Information",
       "Microsoft": "Information"
     }
+  },
+  "App": {
+    "DataRootPath": "../../../data"
   }
 }

--- a/src/to.frontend/to.frontend/appsettings.json
+++ b/src/to.frontend/to.frontend/appsettings.json
@@ -4,5 +4,8 @@
     "LogLevel": {
       "Default": "Warning"
     }
+  },
+  "App": {
+    "DataRootPath": "/TotalOrder"
   }
 }


### PR DESCRIPTION
This PR makes the data path configurable to allow having different paths during development and in production. The path is read from appSettings.json for production and app.Settings.Development.json during dev.

This also fixes inconsistent request handler factory usage in the LoginController.