### PR TITLE
Topic/git actions ci

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -9,7 +9,19 @@ jobs:
     runs-on: ubuntu-18.04
  
     steps:
-    - uses: actions/checkout@v1
-    - name: Build the Docker image
-      run: |
-        docker build . --file src/to.frontend/to.frontend/Dockerfile --tag swyx/totalorder:${GITHUB_SHA}
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Login
+      env:
+        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      run: echo ${DOCKERHUB_PASSWORD} | docker login --username=${DOCKERHUB_USERNAME} --password-stdin
+     
+    - name: Build
+      run: docker build . --file src/to.frontend/to.frontend/Dockerfile --tag swyx/totalorder:${GITHUB_SHA}
+      
+    - name: Push
+      run: docker push swyx/totalorder:${GITHUB_SHA}
+
+  

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,15 @@
+name: Docker Image CI
+
+on: [push]
+
+jobs:
+
+  build:
+ 
+    runs-on: ubuntu-18.04
+ 
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the Docker image
+      run: |
+        docker build . --file src/to.frontend/to.frontend/Dockerfile --tag swyx/totalorder:${GITHUB_SHA}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-## TotalOrder
+# TotalOrder
+
+![badge](https://github.com/martinh2011/totalorder/workflows/.github/workflows/dockerimgage.yml/badge.svg)
 
 Swyx TotalOrder (STO) bringt ehrliche Subjektivitität in das Schätzen von Backlog Issues zurück.
 STO ist das Tool der Wahl, um relatives Schätzen festen Teams oder größeren temporären Gruppen zu ermöglichen.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TotalOrder
 
-![badge](https://github.com/martinh2011/totalorder/workflows/.github/workflows/dockerimgage.yml/badge.svg)
+![badge](https://github.com/swyx/totalorder/workflows/.github/workflows/dockerimgage.yml/badge.svg)
 
 Swyx TotalOrder (STO) bringt ehrliche Subjektivitität in das Schätzen von Backlog Issues zurück.
 STO ist das Tool der Wahl, um relatives Schätzen festen Teams oder größeren temporären Gruppen zu ermöglichen.
@@ -11,6 +11,6 @@ Wer eine Einschätzung für eine Liste von Issues bekommen möchte, registriert 
 Über diesen Code bekommen die Mitglieder Zugang zum Backlog und können die Issues auf der in Frage stehenden Dimension zueinander anordnen. 
 Und der Backlog-Owner bekommt die errechnete Gesamtordnung als Ergebnis zu sehen.
 Backlog-Owner müssen sich registrieren und anmelden, um Backlogs anzulegen und zu verwalten.
-Wer ein Backlog ordnen will, musss sich allerdings nur anmelden, wenn das als Voraussetzung im Backlog eingestellt ist (persönliche Einschätzung).
+Wer ein Backlog ordnen will, muss sich allerdings nur anmelden, wenn das als Voraussetzung im Backlog eingestellt ist (persönliche Einschätzung).
 Bei persönlichen Einschätzungen hat jeder Benutzer nur eine Stimme; mit der kann er seine Einschätzung auch revidieren, wenn das laut Backlog-Einstellung erlaubt ist.
 Bei unpersönlichen/anonymen Einschätzungen hingegen kann jeder Code-Inhaber potenziell mehrfach Backlog-Ordnungen herstellen, die dann auch nicht änderbar sind.

--- a/src/to.backlogrepo/to.backlogrepo.test/to.backlogrepo.test.csproj
+++ b/src/to.backlogrepo/to.backlogrepo.test/to.backlogrepo.test.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.3.0" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />

--- a/src/to.frontend/to.frontend.tests/to.frontend.tests.csproj
+++ b/src/to.frontend/to.frontend.tests/to.frontend.tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="6.2.2" />
     <PackageReference Include="Castle.Core" Version="4.2.1" />
-    <PackageReference Include="FluentAssertions" Version="5.3.0" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />

--- a/src/to.frontend/to.frontend/Dockerfile
+++ b/src/to.frontend/to.frontend/Dockerfile
@@ -1,21 +1,22 @@
-FROM microsoft/aspnetcore-build:2.0 AS build
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-stretch-slim AS base
+WORKDIR /app
+EXPOSE 80
+
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 WORKDIR /src
 COPY to.build.sln ./
-COPY src/to.frontend/to.frontend/to.frontend.csproj src/to.frontend/to.frontend/
-COPY src/to.backlogrepo/to.backlogrepo/to.backlogrepo.csproj src/to.backlogrepo/to.backlogrepo/
-COPY src/to.contracts/to.contracts/to.contracts.csproj src/to.contracts/to.contracts/
-COPY src/to.totalorder/to.totalorder/to.totalorder.csproj src/to.totalorder/to.totalorder/
-COPY src/to.requesthandler/to.requesthandler/to.requesthandler.csproj src/to.requesthandler/to.requesthandler/
-RUN dotnet restore -nowarn:msb3202,nu1503
-COPY . .
+COPY src src/
+COPY docker-compose.dcproj ./docker-compose.dcproj
+RUN dotnet restore -nowarn:msb3202,nu1503 ./to.build.sln && \
+    dotnet build -c release -o /src/contracts/netstandard2.0/ src/to.contracts/to.contracts/to.contracts.csproj && \
+    dotnet build -c Release to.build.sln
+
+RUN dotnet test to.build.sln 
 WORKDIR /src/src/to.frontend/to.frontend
-RUN dotnet build -c Release -o /app
 
 FROM build AS publish
 RUN dotnet publish -c Release -o /app
 
-FROM microsoft/aspnetcore:2.0 AS base
-WORKDIR /app
-EXPOSE 80
+FROM base as final
 COPY --from=publish /app .
 ENTRYPOINT ["dotnet", "to.frontend.dll"]

--- a/src/to.permissionrepo/to.permissionrepo.test/to.permissionrepo.test.csproj
+++ b/src/to.permissionrepo/to.permissionrepo.test/to.permissionrepo.test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.5.3" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />

--- a/src/to.requesthandler/to.requesthandler.test/to.requesthandler.test.csproj
+++ b/src/to.requesthandler/to.requesthandler.test/to.requesthandler.test.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.3.0" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />

--- a/src/to.totalorder/to.totalorder.test/to.totalorder.test.csproj
+++ b/src/to.totalorder/to.totalorder.test/to.totalorder.test.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.3.0" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />

--- a/src/to.userrepo/to.userrepo.test/to.userrepo.test.csproj
+++ b/src/to.userrepo/to.userrepo.test/to.userrepo.test.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.3.0" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NUnit" Version="3.10.1" />


### PR DESCRIPTION
Add a github CI action to build and push totalorder docker image. 

This does not deploy the image to totalorder.de yet.

**Note:** We need to have this on master before the action is executed when something has been pushed