### PR TITLE
fix release workflow fails w/o existing container

### DIFF
--- a/.github/workflows/on-release-publish.yml
+++ b/.github/workflows/on-release-publish.yml
@@ -41,6 +41,6 @@ jobs:
         DOCKER_TLS_VERIFY: 1
         DOCKER_HOST: tcp://cloud.hueser.name:2376
       run: |
-        docker container stop totalorder
-        docker container rm totalorder
+        docker container stop totalorder || true
+        docker container rm totalorder || true
         docker run -d --name totalorder -p 80:80 --restart always -v /data/totalorder:/TotalOrder swyx/totalorder:${GITHUB_SHA}


### PR DESCRIPTION
release workflow now ignores docker stop and docker rm exit codes
to not fail when no existing container is running